### PR TITLE
Added S rank to lib/base/User.js

### DIFF
--- a/lib/base/User.js
+++ b/lib/base/User.js
@@ -64,6 +64,7 @@ class User {
             SSH: Number(data.count_rank_ssh),
             SS: Number(data.count_rank_ss),
             SH: Number(data.count_rank_sh),
+            S: Number(data.count_rank_s),
             A: Number(data.count_rank_a)
         };
 


### PR DESCRIPTION
I noticed a while back that the library was missing the ability to get S ranks. It went straight from Hidden S to A. Quick one-liner to add S support.